### PR TITLE
fix script fails on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "mocha test.js",
     "test:cov": "nyc npm run test",
     "test:loop": "while npm test --silent; do :; done",
-    "preinstall": "unlink-self 2>&1 | echo unlink-self"
+    "preinstall": "node -e \"try { require('unlink-self')() } catch (e) { console.log('unlink-self not available') }\""
   },
   "dependencies": {
     "fs-extra": "^8.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-read-yaml",
-  "version": "1.0.1",
+  "version": "1.1.1",
   "description": "Read and parse a YAML file. A wrapper of js-yaml read file directly.",
   "main": "index.js",
   "scripts": {
@@ -8,8 +8,7 @@
     "lint:fix": "prettier --write . && xo --fix",
     "test": "mocha test.js",
     "test:cov": "nyc npm run test",
-    "test:loop": "while npm test --silent; do :; done",
-    "preinstall": "node -e \"try { require('unlink-self')() } catch (e) { console.log('unlink-self not available') }\""
+    "test:loop": "while npm test --silent; do :; done"
   },
   "dependencies": {
     "fs-extra": "^8.1.0",
@@ -19,7 +18,6 @@
     "chai": "^4.2.0",
     "mocha": "^8.0.1",
     "nyc": "^15.1.0",
-    "node-read-yaml": "file:.",
     "prettier": "latest",
     "unlink-self": "latest",
     "xo": "latest"

--- a/test.js
+++ b/test.js
@@ -3,7 +3,7 @@
 const { writeFileSync, unlinkSync } = require('fs');
 const { resolve } = require('path');
 const { expect } = require('chai');
-const read = require('node-read-yaml');
+const read = require('.');
 const filename = resolve(__dirname, '.test.yml');
 const yamlText1 = `
 _id: 0g3043l9tm


### PR DESCRIPTION
fixes #37 

the fix uses unlink-self if available via node, so that it can run agnostic to the OS